### PR TITLE
Added InputStream attribute to Document object

### DIFF
--- a/src/com/docusign/esignature/json/Document.java
+++ b/src/com/docusign/esignature/json/Document.java
@@ -17,14 +17,18 @@
  
 package com.docusign.esignature.json;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.annotation.Generated;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -43,6 +47,7 @@ public class Document {
     private String documentId;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
     private String contentType;
+    private InputStream documentInputStream;
 
     public String getContentType() {
 		return contentType;
@@ -106,5 +111,13 @@ public class Document {
     public void setAdditionalProperties(String name, Object value) {
         this.additionalProperties.put(name, value);
     }
+
+	public InputStream getDocumentInputStream() {
+		return documentInputStream;
+	}
+
+	public void setDocumentInputStream(InputStream documentInputStream) {
+		this.documentInputStream = documentInputStream;
+	}
 
 }


### PR DESCRIPTION
I added the InputStream reference to the Document object because I wanted to couple the inputstream with the document that is supposed to be sent for signature. 

From my understanding, a request has a list of documents that the request marks separate documents:

request.setDocuments(documents);

In the requestSignatureFromDocuments method of DocuSignClient, it takes that same request along with an inputStream array, which represents the documents that are to be placed in the envelope. My suggestion is that it would make for tighter association between the Docusign document and the InputStream (or File) that it is associated with if it has the InputStream reference within it:

dsClient.requestSignatureFromDocuments(request, documentsToSign);

Thanks, and let me know if you have any suggestions or questions.
:+1: 

Hanke