### PR TITLE
Avoid NPE in OAuth updateAccessToken()

### DIFF
--- a/src/main/java/com/docusign/esign/client/auth/OAuth.java
+++ b/src/main/java/com/docusign/esign/client/auth/OAuth.java
@@ -85,6 +85,9 @@ public class OAuth implements Authentication {
 			throw new ClientHandlerException(e.getMessage(), e);
 		}
 		if (accessTokenResponse != null && accessTokenResponse.getAccessToken() != null) {
+			if ((!accessTokenResponse.has("access_token")) || (!accessTokenResponse.has("expires_in"))) {
+				throw new ApiException("Error while requesting an access token: " + accessTokenResponse);
+			}
 			setAccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getExpiresIn());
 			if (accessTokenListener != null) {
 				accessTokenListener.notify((BasicOAuthToken) accessTokenResponse.getOAuthToken());

--- a/src/main/java/com/docusign/esign/client/auth/OAuth.java
+++ b/src/main/java/com/docusign/esign/client/auth/OAuth.java
@@ -85,7 +85,7 @@ public class OAuth implements Authentication {
 			throw new ClientHandlerException(e.getMessage(), e);
 		}
 		if (accessTokenResponse != null && accessTokenResponse.getAccessToken() != null) {
-			if ((!accessTokenResponse.has("access_token")) || (!accessTokenResponse.has("expires_in"))) {
+			if ((accessTokenResponse.getAccessToken() == null || (accessTokenResponse.getExpiresIn() == null)) {
 				throw new ClientHandlerException("Error while requesting an access token: " + accessTokenResponse);
 			}
 			setAccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getExpiresIn());

--- a/src/main/java/com/docusign/esign/client/auth/OAuth.java
+++ b/src/main/java/com/docusign/esign/client/auth/OAuth.java
@@ -86,7 +86,7 @@ public class OAuth implements Authentication {
 		}
 		if (accessTokenResponse != null && accessTokenResponse.getAccessToken() != null) {
 			if ((!accessTokenResponse.has("access_token")) || (!accessTokenResponse.has("expires_in"))) {
-				throw new ApiException("Error while requesting an access token: " + accessTokenResponse);
+				throw new ClientHandlerException("Error while requesting an access token: " + accessTokenResponse);
 			}
 			setAccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getExpiresIn());
 			if (accessTokenListener != null) {

--- a/src/main/java/com/docusign/esign/client/auth/OAuth.java
+++ b/src/main/java/com/docusign/esign/client/auth/OAuth.java
@@ -85,7 +85,7 @@ public class OAuth implements Authentication {
 			throw new ClientHandlerException(e.getMessage(), e);
 		}
 		if (accessTokenResponse != null && accessTokenResponse.getAccessToken() != null) {
-			if ((accessTokenResponse.getAccessToken() == null || (accessTokenResponse.getExpiresIn() == null)) {
+			if (accessTokenResponse.getAccessToken() == null || accessTokenResponse.getExpiresIn() == null) {
 				throw new ClientHandlerException("Error while requesting an access token: " + accessTokenResponse);
 			}
 			setAccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getExpiresIn());

--- a/src/main/java/com/docusign/esign/client/auth/OAuth.java
+++ b/src/main/java/com/docusign/esign/client/auth/OAuth.java
@@ -85,8 +85,11 @@ public class OAuth implements Authentication {
 			throw new ClientHandlerException(e.getMessage(), e);
 		}
 		if (accessTokenResponse != null && accessTokenResponse.getAccessToken() != null) {
-			if (accessTokenResponse.getAccessToken() == null || accessTokenResponse.getExpiresIn() == null) {
-				throw new ClientHandlerException("Error while requesting an access token: " + accessTokenResponse);
+			if (accessTokenResponse.getAccessToken() == null) {
+				throw new ClientHandlerException("Error while requesting an access token. No 'access_token' found.");
+			}
+			if (accessTokenResponse.getExpiresIn() == null) {
+				throw new ClientHandlerException("Error while requesting an access token. No 'expires_in' found.");
 			}
 			setAccessToken(accessTokenResponse.getAccessToken(), accessTokenResponse.getExpiresIn());
 			if (accessTokenListener != null) {


### PR DESCRIPTION
Avoid NullPointerException in case accessTokenResponse does *not* contain "access_token" or  "expires_in".
For sure this should never happen, but it's part of  negativ test while API integration and makes it more robust.
The additional check was copied from ApiClient.configureJWTAuthorizationFlow()