### PR TITLE
invokeAPI() --> ApiException() if non HTTP 200

### DIFF
--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRe
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.MediaType;
@@ -745,6 +746,10 @@ public class ApiClient {
    public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
 
     ClientResponse response = getAPIResponse(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames);
+
+    if (response.getStatusInfo().getStatusCode() != Status.OK.getStatusCode()) {
+        throw new ApiException("Error while requesting server, received HTTP code: "+ response.getStatusInfo().getStatusCode() + " / with response Body: " + response.getEntity(String.class));
+    }
 
     statusCode = response.getStatusInfo().getStatusCode();
     responseHeaders = response.getHeaders();

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -22,7 +22,6 @@ import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRe
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 
-import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.MediaType;
@@ -747,8 +746,8 @@ public class ApiClient {
 
     ClientResponse response = getAPIResponse(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames);
 
-    if (response.getStatusInfo().getStatusCode() != Status.OK.getStatusCode()) {
-        throw new ApiException("Error while requesting server, received HTTP code: "+ response.getStatusInfo().getStatusCode() + " / with response Body: " + response.getEntity(String.class));
+    if (response.getStatusInfo().getFamily() != Family.SUCCESSFUL) {
+        throw new ApiException("Error while requesting server, received HTTP code: " + response.getStatusInfo().getStatusCode() + " / with response Body: " + response.getEntity(String.class));
     }
 
     statusCode = response.getStatusInfo().getStatusCode();

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -57,6 +57,7 @@ public class ApiClient {
   private String basePath = "https://www.docusign.net/restapi";
   private boolean debugging = false;
   private int connectionTimeout = 0;
+  private int readTimeout = 0;
 
   private Client httpClient;
   private ObjectMapper mapper;
@@ -317,6 +318,24 @@ public class ApiClient {
    public ApiClient setConnectTimeout(int connectionTimeout) {
      this.connectionTimeout = connectionTimeout;
      httpClient.setConnectTimeout(connectionTimeout);
+     return this;
+   }
+
+  /**
+   * Read timeout (in milliseconds).
+   */
+  public int getReadTimeout() {
+    return readTimeout;
+  }
+
+  /**
+   * Set the read timeout (in milliseconds).
+   * A value of 0 means no timeout, otherwise values must be between 1 and
+   * {@link Integer#MAX_VALUE}.
+   */
+   public ApiClient setReadTimeout(int readTimeout) {
+     this.readTimeout = readTimeout;
+     httpClient.setReadTimeout(readTimeout);
      return this;
    }
 


### PR DESCRIPTION
There was no error indication in case the restapi request gets back a non HTTP 200 code, e.g. HTTP 400 / 401 / 403 / ....