### PR TITLE
invokeAPI populate response object in ApiException for non successful…

### DIFF
--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -766,8 +766,7 @@ public class ApiClient {
     ClientResponse response = getAPIResponse(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames);
 
     if (response.getStatusInfo().getFamily() != Family.SUCCESSFUL) {
-        String respBody = null;
-        respBody = response.getEntity(String.class);
+        String respBody = response.getEntity(String.class);
         throw new ApiException(
             response.getStatusInfo().getStatusCode(),
             "Error while requesting server, received a non successful HTTP code " + response.getStatusInfo().getStatusCode() + " with response Body: '" + respBody + "'",

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -766,7 +766,13 @@ public class ApiClient {
     ClientResponse response = getAPIResponse(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames);
 
     if (response.getStatusInfo().getFamily() != Family.SUCCESSFUL) {
-        throw new ApiException("Error while requesting server, received HTTP code: " + response.getStatusInfo().getStatusCode() + " / with response Body: " + response.getEntity(String.class));
+        String respBody = null;
+        respBody = response.getEntity(String.class);
+        throw new ApiException(
+            response.getStatusInfo().getStatusCode(),
+            "Error while requesting server, received a non successful HTTP code " + response.getStatusInfo().getStatusCode() + " with response Body: '" + respBody + "'",
+            response.getHeaders(),
+            respBody);
     }
 
     statusCode = response.getStatusInfo().getStatusCode();


### PR DESCRIPTION
… HTTP codes

This PR is for the issue #68 request to populate the response in ApiException object for non successful HTTP codes.
With that change the client code can process on it.