### PR TITLE
Fixing issue with `Incorrect access token`

### DIFF
--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -272,7 +272,7 @@ public class ApiClient {
       OAuth oAuth = new OAuth(null, null, null) {
           @Override
           public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {
-              headerParams.put("Authorization", "Bearer " + accessToken);
+              headerParams.put("Authorization", "Bearer " + getAccessToken());
           }
       };
       oAuth.setAccessToken(accessToken, expiresIn);


### PR DESCRIPTION
Currently, because of a closure of the `accessToken` variable, sometimes we're having authorization header with an incorrect access token.

But getting access token directly from the getter method should eliminate such issue.