### PR TITLE
surface auth error for JWTUserToken()

### DIFF
--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -720,7 +720,7 @@ public class ApiClient {
       mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
       OAuth.OAuthToken oAuthToken = mapper.readValue(response.getEntityInputStream(), OAuth.OAuthToken.class);
       if (oAuthToken.getAccessToken() == null || oAuthToken.getAccessToken() == "" || oAuthToken.getExpiresIn() <= 0) {
-        throw new ApiException("Error while requesting an access token: " + oAuthToken);
+        throw new ApiException("Error while requesting an access token: " + response.toString());
       }
       return oAuthToken;
     } catch (JsonParseException e) {


### PR DESCRIPTION
Return the account server response status and message instead of a null token on certain exceptions caught by the requestJWTUserToken() method.