### PR TITLE
version 2.9.0 of the Java SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # DocuSign Java Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v2.9.0] - eSignature API v18.4.02 - 2019-02-27
+### Added
+- Support for the **latest DocuSign API** (18.4.02.00).
+- Support for HTTP(S) proxy through System Properties. The supported proxy parameters are:
+  - For HTTPS (recommended): https.proxyHost, https.proxyPort, https.proxyUser and https.proxyPassword
+  - For HTTP: http.proxyHost, http.proxyPort, http.proxyUser and http.proxyPassword
+### Fixed
+- Fixed a problem with the AccountsApi.UpdateBrandLogoByType method that prevented it from uploading brand logos.
+- Fixed AuthName comparison. (DCM-3160)
+
 ## [v2.9.0-RC1] - eSignature API v18.4.02 - 2019-02-15
 ### Added
 - Support for the **latest DocuSign API** (18.4.02.00).
-- Ability to upload a brand logo through updateBrandLogoByType
+- Fixed a problem with the AccountsApi.UpdateBrandLogoByType method that prevented it from uploading brand logos.
 - Support for HTTP(S) proxy through System Properties. The supported proxy parameters are:
   - For HTTPS (recommended): https.proxyHost, https.proxyPort, https.proxyUser and https.proxyPassword
   - For HTTP: http.proxyHost, http.proxyPort, http.proxyUser and http.proxyPassword

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this dependency to your project's POM:
 <dependency>
    <groupId>com.docusign</groupId>
    <artifactId>docusign-esign-java</artifactId>
-   <version>2.9.0-RC1</version>
+   <version>2.9.0</version>
 </dependency>
 ```
 
@@ -30,7 +30,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.docusign:docusign-esign-java:2.9.0-RC1"
+compile "com.docusign:docusign-esign-java:2.9.0"
 ```
 
 #### Dependencies
@@ -73,8 +73,8 @@ android {
 
 This client is available through the following Java package managers:
 
-- [Nexus Repository Manager](https://oss.sonatype.org/#nexus-search;quick~docusign-esign-java) (oss.sonatype.org). You can search for com.docusign or docusign-esign-java. The current version is 2.9.0-RC1.
-- [JFrog Bintray](https://bintray.com/dsdevcenter/maven/docusign-esign-java) (bintray.com). You can search for com.docusign or docusign-esign-java. The current version is 2.9.0-RC1.
+- [Nexus Repository Manager](https://oss.sonatype.org/#nexus-search;quick~docusign-esign-java) (oss.sonatype.org). You can search for com.docusign or docusign-esign-java. The current version is 2.9.0.
+- [JFrog Bintray](https://bintray.com/dsdevcenter/maven/docusign-esign-java) (bintray.com). You can search for com.docusign or docusign-esign-java. The current version is 2.9.0.
 
 
 Usage

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 group = 'com.docusign'
-version = '2.9.0-RC1'
+version = '2.9.0'
 
 buildscript {
     repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>docusign-esign-java</artifactId>
   <packaging>jar</packaging>
   <name>docusign-esign-java</name>
-  <version>2.9.0-RC-1</version>
+  <version>2.9.0</version>
   <description>The official DocuSign eSignature JAVA client is based on version 2 of the DocuSign REST API and provides libraries for JAVA application integration. It is recommended that you use this version of the library for new development.</description>
   <url>https://www.docusign.com/developer-center</url>
 

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -147,9 +147,9 @@ public class ApiClient {
     this.setOAuthBasePath(oAuthBasePath);
     for(String authName : authNames) {
       Authentication auth;
-      if (authName == "docusignAccessCode") {
+      if ("docusignAccessCode".equals(authName)) {
         auth = new OAuth(httpClient, OAuthFlow.accessCode, oAuthBasePath + "/oauth/auth", oAuthBasePath + "/oauth/token", "all");
-      } else if (authName == "docusignApiKey") {
+      } else if ("docusignApiKey".equals(authName)) {
         auth = new ApiKeyAuth("header", "docusignApiKey");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
@@ -594,7 +594,7 @@ public class ApiClient {
    */
   public OAuth.UserInfo getUserInfo(String accessToken) throws IllegalArgumentException, ApiException {
     try {
-      if (accessToken == null || accessToken == "") {
+      if (accessToken == null || "".equals(accessToken)) {
         throw new IllegalArgumentException("Cannot find a valid access token. Make sure OAuth is configured before you try again.");
       }
 
@@ -736,7 +736,7 @@ public class ApiClient {
       ObjectMapper mapper = new ObjectMapper();
       mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
       OAuth.OAuthToken oAuthToken = mapper.readValue(response.getEntityInputStream(), OAuth.OAuthToken.class);
-      if (oAuthToken.getAccessToken() == null || oAuthToken.getAccessToken() == "" || oAuthToken.getExpiresIn() <= 0) {
+      if (oAuthToken.getAccessToken() == null || "".equals(oAuthToken.getAccessToken()) || oAuthToken.getExpiresIn() <= 0) {
         throw new ApiException("Error while requesting an access token: " + response.toString());
       }
       return oAuthToken;

--- a/src/main/java/com/docusign/esign/client/auth/JWTUtils.java
+++ b/src/main/java/com/docusign/esign/client/auth/JWTUtils.java
@@ -49,7 +49,7 @@ public class JWTUtils {
 		if (rsaPrivateKey == null || rsaPrivateKey.length == 0) {
 			throw new IllegalArgumentException("rsaPrivateKey byte array is empty");
 		}
-		if (oAuthBasePath == null || oAuthBasePath == "" || clientId == null || clientId == "") {
+		if (oAuthBasePath == null || "".equals(oAuthBasePath) || clientId == null || "".equals(clientId)) {
 			throw new IllegalArgumentException("One of the arguments is null or empty");
 		}
 		
@@ -85,7 +85,7 @@ public class JWTUtils {
 		  if (expiresIn <= 0L) {
 				throw new IllegalArgumentException("expiresIn should be a non-negative value");
 		  }
-		  if (publicKeyFilename == null || publicKeyFilename == "" || privateKeyFilename == null || privateKeyFilename == "" || oAuthBasePath == null || oAuthBasePath == "" || clientId == null || clientId == "" || userId == null || userId == "") {
+		  if (publicKeyFilename == null || "".equals(publicKeyFilename) || privateKeyFilename == null || "".equals(privateKeyFilename) || oAuthBasePath == null || "".equals(oAuthBasePath) || clientId == null || "".equals(clientId) || userId == null || "".equals(userId)) {
 				throw new IllegalArgumentException("One of the arguments is null or empty");
 		  }
 


### PR DESCRIPTION
### Added
- Support for the **latest DocuSign API** (18.4.02.00).
- Support for HTTP(S) proxy through System Properties. The supported proxy parameters are:
  - For HTTPS (recommended): https.proxyHost, https.proxyPort, https.proxyUser and https.proxyPassword
  - For HTTP: http.proxyHost, http.proxyPort, http.proxyUser and http.proxyPassword
### Fixed
- Fixed a problem with the AccountsApi.UpdateBrandLogoByType method that prevented it from uploading brand logos.
- Fixed AuthName comparison. (DCM-3160)